### PR TITLE
[26259] Saved instance exception

### DIFF
--- a/filestack/build.gradle
+++ b/filestack/build.gradle
@@ -18,7 +18,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 group = 'com.filestack'
-version = '5.6.3'
+version = '5.6.4'
 project.archivesBaseName = 'fieldwire-filestack-android'
 
 android {

--- a/filestack/src/main/java/com/filestack/android/FsActivity.java
+++ b/filestack/src/main/java/com/filestack/android/FsActivity.java
@@ -357,7 +357,7 @@ public class FsActivity extends AppCompatActivity implements
     private void showFragment(Fragment fragment) {
         getSupportFragmentManager().beginTransaction()
                 .replace(R.id.content, fragment)
-                .commit();
+                .commitAllowingStateLoss();
     }
 
     private void checkAuth() {


### PR DESCRIPTION
https://console.firebase.google.com/u/0/project/cool-reality-510/crashlytics/app/android:net.fieldwire.app/issues/e276077f490375d65fe6691198cdec53?time=last-seven-days&sessionEventKey=60AF0AE0009000011EA99FB502200BC2_1545244746786240262

Fix for this crash

Before we switch a fragment filestack makes an api call it commits the fragment when `onSuccess` is called. Crash happens if `commit` gets called after `onSaveInstanceState`. 