### PR TITLE
[26280] updated mime validator to short-circuit for all allowed mime types

### DIFF
--- a/filestack/build.gradle
+++ b/filestack/build.gradle
@@ -18,7 +18,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 group = 'com.filestack'
-version = '5.6.4'
+version = '5.6.5'
 project.archivesBaseName = 'fieldwire-filestack-android'
 
 android {

--- a/filestack/src/main/java/com/filestack/android/internal/CloudListAdapter.java
+++ b/filestack/src/main/java/com/filestack/android/internal/CloudListAdapter.java
@@ -1,7 +1,6 @@
 package com.filestack.android.internal;
 
 import android.os.Bundle;
-import androidx.core.graphics.ColorUtils;
 import androidx.recyclerview.widget.RecyclerView;
 import android.text.TextUtils;
 import android.text.format.Formatter;

--- a/filestack/src/main/java/com/filestack/android/internal/Util.java
+++ b/filestack/src/main/java/com/filestack/android/internal/Util.java
@@ -17,6 +17,7 @@ import java.io.File;
 import java.io.IOException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -221,6 +222,7 @@ public class Util {
 
     /** Returns true if the MIME type is allowed by the filters. */
     public static boolean mimeAllowed(String[] filters, String mimeType) {
-        return MimeTypeFilter.matches(mimeType, filters) != null;
+        boolean allTypesAllowed = Arrays.asList(filters).contains("*/*");
+        return allTypesAllowed || MimeTypeFilter.matches(mimeType, filters) != null;
     }
 }


### PR DESCRIPTION
https://app.fieldwire.com/#!/projects/9e2e9c0c-4abf-490b-b269-6862c279afee/tasks/4d9bd132-8219-4c70-ad63-502fdbf23789

Previously, `Util.mimeAllowed` would compare the mimetype of the file in question against the list of allowed mime types. However, the comparison fails if Filestack found a file's mime type to be null, resulting in the row for the file to be disabled. A possible update to the logic would be to short-circuit the mimetype validation so that if the list of allowed mime types contains `*/*`, the file's mime type - null or otherwise - should not be an issue.

| Before  | After |
| ------------- | ------------- |
| <img width="300" alt="Screen Shot 2021-05-29 at 2 20 06 AM" src="https://user-images.githubusercontent.com/4399290/120065478-59093d00-c026-11eb-9b5f-ac68384438fa.png">  | <img width="300" alt="Screen Shot 2021-05-29 at 2 26 28 AM" src="https://user-images.githubusercontent.com/4399290/120065480-59a1d380-c026-11eb-8dea-9c620b05fe21.png"> |


