### PR TITLE
[ME-828] Always override client with new config

### DIFF
--- a/filestack/src/main/java/com/filestack/android/FsActivity.java
+++ b/filestack/src/main/java/com/filestack/android/FsActivity.java
@@ -187,7 +187,7 @@ public class FsActivity extends AppCompatActivity implements
         Config config = (Config) intent.getSerializableExtra(FsConstants.EXTRA_CONFIG);
         if (config != null) {
             String sessionToken = preferences.getString(PREF_SESSION_TOKEN, null);
-            Util.initializeClientIfNeeded(config, sessionToken);
+            Util.initializeClient(config, sessionToken);
 
             if (savedInstanceState == null) {
                 Util.getSelectionSaver().clear();

--- a/filestack/src/main/java/com/filestack/android/internal/Util.java
+++ b/filestack/src/main/java/com/filestack/android/internal/Util.java
@@ -203,17 +203,18 @@ public class Util {
         context.sendBroadcast(mediaScanIntent);
     }
 
-    /** Create the Java SDK client and set a session token. The token maintains cloud auth state. */
-    public static void initializeClientIfNeeded(Config config, String sessionToken) {
-        if (client == null) {
-            // Override returnUrl until introduction of FilestackUi class which will allow to set this
-            // all up manually.
-            Config overridenConfig = new Config(config.getApiKey(), "filestack://done",
-                    config.getPolicy(), config.getSignature());
+    /** Create the Java SDK client and set a session token. The token maintains cloud auth state.
+     *  Always create a new Client with the passed in config, so that we're not re-using the old config which could
+     *  route the upload flow to unintended upload destination
+     */
+    public static void initializeClient(Config config, String sessionToken) {
+        // Override returnUrl until introduction of FilestackUi class which will allow to set this
+        // all up manually.
+        Config overridenConfig = new Config(config.getApiKey(), "filestack://done",
+                config.getPolicy(), config.getSignature());
 
-            client = new Client(overridenConfig);
-            client.setSessionToken(sessionToken);
-        }
+        client = new Client(overridenConfig);
+        client.setSessionToken(sessionToken);
     }
 
     public static Client getClient() {


### PR DESCRIPTION
https://fieldwire.atlassian.net/browse/ME-828

Previously, we only initialized the Client object (used to upload files for Filestack) when it's `null` and reuse the same object if it's not (even though there might have been a different config param passed in, i.e. config with a different region). 

Additionally, Filestack is currently being set on a different process as compared to our application (separate `android:process` is set in the AndroidManifest, this was to avoid crashes from Filestack to impact our application since it's not being maintained anymore), thus even though the Filestack Activity might be dismissed, it still retains all the references to the previous usage.

TLDR; Filestack reuses the same storage config once it sets even though we create a new FilestackPicker with new config every time, so removing the `client == null` logic lets the `initializeClient()` call to set the client every time so we don't reuse the old config.