### PR TITLE
added file info text for grid layout

### DIFF
--- a/filestack/src/main/java/com/filestack/android/internal/CloudListFragment.java
+++ b/filestack/src/main/java/com/filestack/android/internal/CloudListFragment.java
@@ -83,7 +83,7 @@ public class CloudListFragment extends Fragment implements BackButtonListener {
         }
 
         int spacing = getResources().getDimensionPixelSize(R.dimen.filestack__grid_spacing);
-        spacer = new SpacingDecoration(spacing, spacing, false);
+        spacer = new SpacingDecoration(spacing, spacing * 2, false);
 
         setupRecyclerLayout();
 

--- a/filestack/src/main/res/layout/filestack__cloud_grid_item.xml
+++ b/filestack/src/main/res/layout/filestack__cloud_grid_item.xml
@@ -1,22 +1,54 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content">
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
 
-    <com.filestack.android.internal.SquareImageView
-        android:id="@+id/icon"
+    <FrameLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <com.filestack.android.internal.SquareImageView
+            android:id="@+id/icon"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:scaleType="centerCrop" />
+
+        <ImageView
+            android:id="@+id/checkbox"
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:layout_margin="8dp"
+            android:importantForAccessibility="no"
+            android:visibility="invisible"
+            app:srcCompat="@drawable/filestack__ic_list_checkbox" />
+
+    </FrameLayout>
+
+    <TextView
+        android:id="@+id/name"
+        style="@style/TextAppearance.AppCompat.Subhead"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:scaleType="centerCrop"/>
+        android:layout_marginEnd="@dimen/filestack__list_item_horizontal_padding"
+        android:layout_marginRight="@dimen/filestack__list_item_horizontal_padding"
+        android:ellipsize="end"
+        android:gravity="center"
+        android:maxLines="1"
+        tools:text="NAME OF THE FILE" />
 
-    <ImageView
-        app:srcCompat="@drawable/filestack__ic_list_checkbox"
-        android:id="@+id/checkbox"
-        android:layout_width="24dp"
-        android:layout_height="24dp"
-        android:visibility="invisible"
-        android:layout_margin="8dp"/>
-
-</FrameLayout>
+    <TextView
+        android:id="@+id/info"
+        style="@style/TextAppearance.AppCompat.Body1"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="@dimen/filestack__list_item_horizontal_padding"
+        android:layout_marginRight="@dimen/filestack__list_item_horizontal_padding"
+        android:ellipsize="end"
+        android:gravity="center"
+        android:maxLines="1"
+        android:textColor="@color/filestack__text_secondary"
+        tools:text="DESCRIPTION OF THE FILE" />
+</LinearLayout>

--- a/tester/src/main/java/com/filestack/android/demo/MainActivity.java
+++ b/tester/src/main/java/com/filestack/android/demo/MainActivity.java
@@ -3,6 +3,7 @@ package com.filestack.android.demo;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.SharedPreferences;
+import android.graphics.Color;
 import android.os.Bundle;
 import androidx.core.content.ContextCompat;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
@@ -69,7 +70,7 @@ public class MainActivity extends AppCompatActivity {
         String mimeFilter = sharedPref.getString("mime_filter", null);
         List<String> mimeTypes = Arrays.asList(mimeFilter.split(","));
 
-        String apiKey = sharedPref.getString("api_key", null);
+        String apiKey = "ACGv8iMoCTXS27m716Xsqz";// sharedPref.getString("api_key", null);
         String policy = sharedPref.getString("policy", null);
         String signature = sharedPref.getString("signature", null);
 
@@ -81,8 +82,9 @@ public class MainActivity extends AppCompatActivity {
 
         Theme theme = new Theme.Builder()
                 .title(sharedPref.getString("theme_title", null))
-                .accentColor(sharedPref.getInt("theme_accent", ContextCompat.getColor(this, R.color.colorAccent)))
-                .backgroundColor(sharedPref.getInt("theme_background", ContextCompat.getColor(this, R.color.colorPrimary)))
+                //.accentColor(sharedPref.getInt("theme_accent", ContextCompat.getColor(this, R.color.colorAccent)))
+                // .accentColor(Color.rgb(53, 58, 67))
+                // .backgroundColor(sharedPref.getInt("theme_background", ContextCompat.getColor(this, R.color.colorPrimary)))
                 .textColor(sharedPref.getInt("theme_text", ContextCompat.getColor(this, R.color.text)))
                 .build();
 

--- a/tester/src/main/java/com/filestack/android/demo/MainActivity.java
+++ b/tester/src/main/java/com/filestack/android/demo/MainActivity.java
@@ -3,7 +3,6 @@ package com.filestack.android.demo;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.SharedPreferences;
-import android.graphics.Color;
 import android.os.Bundle;
 import androidx.core.content.ContextCompat;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
@@ -70,7 +69,7 @@ public class MainActivity extends AppCompatActivity {
         String mimeFilter = sharedPref.getString("mime_filter", null);
         List<String> mimeTypes = Arrays.asList(mimeFilter.split(","));
 
-        String apiKey = "ACGv8iMoCTXS27m716Xsqz";// sharedPref.getString("api_key", null);
+        String apiKey = sharedPref.getString("api_key", null);
         String policy = sharedPref.getString("policy", null);
         String signature = sharedPref.getString("signature", null);
 
@@ -82,9 +81,8 @@ public class MainActivity extends AppCompatActivity {
 
         Theme theme = new Theme.Builder()
                 .title(sharedPref.getString("theme_title", null))
-                //.accentColor(sharedPref.getInt("theme_accent", ContextCompat.getColor(this, R.color.colorAccent)))
-                // .accentColor(Color.rgb(53, 58, 67))
-                // .backgroundColor(sharedPref.getInt("theme_background", ContextCompat.getColor(this, R.color.colorPrimary)))
+                .accentColor(sharedPref.getInt("theme_accent", ContextCompat.getColor(this, R.color.colorAccent)))
+                .backgroundColor(sharedPref.getInt("theme_background", ContextCompat.getColor(this, R.color.colorPrimary)))
                 .textColor(sharedPref.getInt("theme_text", ContextCompat.getColor(this, R.color.text)))
                 .build();
 


### PR DESCRIPTION
https://fieldwire.atlassian.net/browse/ME-361

in the original issue. the file info text was missing on grid view. this was originally by design of the filestack library (only icon/thumbnail was displayed in grid view). the textViews for file info have been updated to the grid layout, and padding adjusted for visibility. the text is set to single-line to avoid the ui being too cluttered. but this can be adjusted as needed

<img width="300" src="https://github.com/user-attachments/assets/adb0e3d1-5bd5-4bd4-85bd-25bab642c76b"/>
