### PR TITLE
SDK Bump 34 -> 35 and Updates

### DIFF
--- a/filestack/build.gradle
+++ b/filestack/build.gradle
@@ -6,11 +6,11 @@ version = '5.6.8'
 project.archivesBaseName = 'fieldwire-filestack-android'
 
 android {
-    compileSdk 34
+    compileSdk 35
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 34
+        targetSdkVersion 35
 
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
 

--- a/filestack/build.gradle
+++ b/filestack/build.gradle
@@ -44,8 +44,6 @@ dependencies {
 
     implementation 'androidx.appcompat:appcompat:1.2.0'
 
-    implementation 'androidx.core:core-ktx:1.12.0'
-
     implementation 'androidx.browser:browser:1.3.0'
     // glide 
     implementation 'com.github.bumptech.glide:glide:4.12.0'

--- a/filestack/build.gradle
+++ b/filestack/build.gradle
@@ -44,6 +44,8 @@ dependencies {
 
     implementation 'androidx.appcompat:appcompat:1.2.0'
 
+    implementation 'androidx.core:core-ktx:1.12.0'
+
     implementation 'androidx.browser:browser:1.3.0'
     // glide 
     implementation 'com.github.bumptech.glide:glide:4.12.0'

--- a/filestack/src/main/java/com/filestack/android/FsActivity.java
+++ b/filestack/src/main/java/com/filestack/android/FsActivity.java
@@ -135,20 +135,20 @@ public class FsActivity extends AppCompatActivity implements
             System.out.println("FSActivity Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP");
             progressBar.setIndeterminateTintList(ColorStateList.valueOf(theme.getAccentColor()));
         }
-//
-//        // Enable edge-to-edge rendering
-//        WindowCompat.setDecorFitsSystemWindows(getWindow(), false);
-//
-//        // Apply system bar color and icon contrast
-//        View decorView = getWindow().getDecorView();
-//        WindowInsetsControllerCompat insetsController = ViewCompat.getWindowInsetsController(decorView);
-//
-//        // Adjust status bar icon color (true = light icons, false = dark icons)
-//        boolean useLightIcons = ColorUtils.calculateLuminance(theme.getAccentColor()) < 0.5;
-//        insetsController.setAppearanceLightStatusBars(!useLightIcons);
-//
-//        // Apply background color under system bars (optional visual match)
-//        decorView.setBackgroundColor(theme.getAccentColor());
+
+        // Enable edge-to-edge rendering
+        WindowCompat.setDecorFitsSystemWindows(getWindow(), false);
+
+        // Apply system bar color and icon contrast
+        View decorView = getWindow().getDecorView();
+        WindowInsetsControllerCompat insetsController = ViewCompat.getWindowInsetsController(decorView);
+
+        // Adjust status bar icon color (true = light icons, false = dark icons)
+        boolean useLightIcons = ColorUtils.calculateLuminance(theme.getAccentColor()) < 0.5;
+        insetsController.setAppearanceLightStatusBars(!useLightIcons);
+
+        // Apply background color under system bars (optional visual match)
+        decorView.setBackgroundColor(theme.getAccentColor());
 
         getSupportActionBar().setTitle(theme.getTitle());
         toolbar.setTitleTextColor(theme.getBackgroundColor());

--- a/filestack/src/main/java/com/filestack/android/FsActivity.java
+++ b/filestack/src/main/java/com/filestack/android/FsActivity.java
@@ -58,10 +58,6 @@ import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.schedulers.Schedulers;
 
-import androidx.core.view.WindowCompat;
-import androidx.core.view.WindowInsetsControllerCompat;
-import androidx.core.view.ViewCompat;
-
 import static com.filestack.android.utils.RxUtils.zipWithTimer;
 
 /** UI to select and upload files from local and cloud sources.
@@ -113,7 +109,6 @@ public class FsActivity extends AppCompatActivity implements
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
-        System.out.println("FSActivity.onCreate()");
         super.onCreate(savedInstanceState);
         Intent intent = getIntent();
         SharedPreferences preferences = getPreferences(MODE_PRIVATE);
@@ -130,25 +125,8 @@ public class FsActivity extends AppCompatActivity implements
         }
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-//            getWindow().setStatusBarColor(theme.getAccentColor());
-//            Log.i("PLIUUU","FSActivity Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP");
-            System.out.println("FSActivity Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP");
             progressBar.setIndeterminateTintList(ColorStateList.valueOf(theme.getAccentColor()));
         }
-
-        // Enable edge-to-edge rendering
-        WindowCompat.setDecorFitsSystemWindows(getWindow(), false);
-
-        // Apply system bar color and icon contrast
-        View decorView = getWindow().getDecorView();
-        WindowInsetsControllerCompat insetsController = ViewCompat.getWindowInsetsController(decorView);
-
-        // Adjust status bar icon color (true = light icons, false = dark icons)
-        boolean useLightIcons = ColorUtils.calculateLuminance(theme.getAccentColor()) < 0.5;
-        insetsController.setAppearanceLightStatusBars(!useLightIcons);
-
-        // Apply background color under system bars (optional visual match)
-        decorView.setBackgroundColor(theme.getAccentColor());
 
         getSupportActionBar().setTitle(theme.getTitle());
         toolbar.setTitleTextColor(theme.getBackgroundColor());

--- a/filestack/src/main/java/com/filestack/android/FsActivity.java
+++ b/filestack/src/main/java/com/filestack/android/FsActivity.java
@@ -109,6 +109,7 @@ public class FsActivity extends AppCompatActivity implements
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
+        System.out.println("FSActivity.onCreate()");
         super.onCreate(savedInstanceState);
         Intent intent = getIntent();
         SharedPreferences preferences = getPreferences(MODE_PRIVATE);

--- a/filestack/src/main/java/com/filestack/android/FsActivity.java
+++ b/filestack/src/main/java/com/filestack/android/FsActivity.java
@@ -58,6 +58,10 @@ import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.schedulers.Schedulers;
 
+import androidx.core.view.WindowCompat;
+import androidx.core.view.WindowInsetsControllerCompat;
+import androidx.core.view.ViewCompat;
+
 import static com.filestack.android.utils.RxUtils.zipWithTimer;
 
 /** UI to select and upload files from local and cloud sources.
@@ -126,9 +130,26 @@ public class FsActivity extends AppCompatActivity implements
         }
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            getWindow().setStatusBarColor(theme.getAccentColor());
+//            getWindow().setStatusBarColor(theme.getAccentColor());
+//            Log.i("PLIUUU","FSActivity Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP");
+            System.out.println("FSActivity Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP");
             progressBar.setIndeterminateTintList(ColorStateList.valueOf(theme.getAccentColor()));
         }
+//
+//        // Enable edge-to-edge rendering
+//        WindowCompat.setDecorFitsSystemWindows(getWindow(), false);
+//
+//        // Apply system bar color and icon contrast
+//        View decorView = getWindow().getDecorView();
+//        WindowInsetsControllerCompat insetsController = ViewCompat.getWindowInsetsController(decorView);
+//
+//        // Adjust status bar icon color (true = light icons, false = dark icons)
+//        boolean useLightIcons = ColorUtils.calculateLuminance(theme.getAccentColor()) < 0.5;
+//        insetsController.setAppearanceLightStatusBars(!useLightIcons);
+//
+//        // Apply background color under system bars (optional visual match)
+//        decorView.setBackgroundColor(theme.getAccentColor());
+
         getSupportActionBar().setTitle(theme.getTitle());
         toolbar.setTitleTextColor(theme.getBackgroundColor());
         toolbar.setSubtitleTextColor(ColorUtils.setAlphaComponent(theme.getBackgroundColor(), 220));

--- a/filestack/src/main/java/com/filestack/android/FsActivity.java
+++ b/filestack/src/main/java/com/filestack/android/FsActivity.java
@@ -127,7 +127,6 @@ public class FsActivity extends AppCompatActivity implements
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             progressBar.setIndeterminateTintList(ColorStateList.valueOf(theme.getAccentColor()));
         }
-
         getSupportActionBar().setTitle(theme.getTitle());
         toolbar.setTitleTextColor(theme.getBackgroundColor());
         toolbar.setSubtitleTextColor(ColorUtils.setAlphaComponent(theme.getBackgroundColor(), 220));

--- a/tester/src/main/java/com/filestack/android/demo/MainActivity.java
+++ b/tester/src/main/java/com/filestack/android/demo/MainActivity.java
@@ -73,8 +73,6 @@ public class MainActivity extends AppCompatActivity {
         String policy = sharedPref.getString("policy", null);
         String signature = sharedPref.getString("signature", null);
 
-//        FSActivity.onCreate()
-        System.out.println(apiKey);
 
         if (apiKey == null) {
             Toast.makeText(this, R.string.error_no_api_key, Toast.LENGTH_SHORT).show();

--- a/tester/src/main/java/com/filestack/android/demo/MainActivity.java
+++ b/tester/src/main/java/com/filestack/android/demo/MainActivity.java
@@ -73,6 +73,9 @@ public class MainActivity extends AppCompatActivity {
         String policy = sharedPref.getString("policy", null);
         String signature = sharedPref.getString("signature", null);
 
+//        FSActivity.onCreate()
+        System.out.println(apiKey);
+
         if (apiKey == null) {
             Toast.makeText(this, R.string.error_no_api_key, Toast.LENGTH_SHORT).show();
             return;

--- a/tester/src/main/java/com/filestack/android/demo/MainActivity.java
+++ b/tester/src/main/java/com/filestack/android/demo/MainActivity.java
@@ -73,7 +73,6 @@ public class MainActivity extends AppCompatActivity {
         String policy = sharedPref.getString("policy", null);
         String signature = sharedPref.getString("signature", null);
 
-
         if (apiKey == null) {
             Toast.makeText(this, R.string.error_no_api_key, Toast.LENGTH_SHORT).show();
             return;


### PR DESCRIPTION
https://fieldwire.atlassian.net/browse/ME-4166

Things done:
* remove `setStatusBarColor` since that will be deprecated in android 15
* bump target and compile SDK to 35

Testing:
* Use the tester app and see that functionality remains the same
* NOTE* Status bar becomes black and double checked with product and they are okay with it

Before:
https://github.com/user-attachments/assets/634335a0-dc35-406a-88b0-3b2bf84a3035

After:
https://github.com/user-attachments/assets/8945cec0-341b-44ad-94bd-33988cce2f89


