### PR TITLE
[ME-7078] Exclude SVG selection for upload

### DIFF
--- a/filestack/src/main/AndroidManifest.xml
+++ b/filestack/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
+    <!-- Required for foreground service on API 28+ -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <!-- Permission for data sync in foreground service. Mandatory from API 34. -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC"
         android:minSdkVersion="34" />

--- a/filestack/src/main/java/com/filestack/android/FsActivity.java
+++ b/filestack/src/main/java/com/filestack/android/FsActivity.java
@@ -411,9 +411,11 @@ public class FsActivity extends AppCompatActivity implements
         if (autoUpload) {
             StorageOptions storeOpts = (StorageOptions) activityIntent
                     .getSerializableExtra(FsConstants.EXTRA_STORE_OPTS);
+            String[] mimeTypes = activityIntent.getStringArrayExtra(FsConstants.EXTRA_MIME_TYPES);
             Intent uploadIntent = new Intent(this, UploadService.class);
             uploadIntent.putExtra(FsConstants.EXTRA_STORE_OPTS, storeOpts);
             uploadIntent.putExtra(FsConstants.EXTRA_SELECTION_LIST, selections);
+            uploadIntent.putExtra(FsConstants.EXTRA_MIME_TYPES, mimeTypes);
             ContextCompat.startForegroundService(this, uploadIntent);
         }
 

--- a/filestack/src/main/java/com/filestack/android/internal/CloudListAdapter.java
+++ b/filestack/src/main/java/com/filestack/android/internal/CloudListAdapter.java
@@ -107,7 +107,8 @@ class CloudListAdapter extends RecyclerView.Adapter<CloudListViewHolder> impleme
         holder.setInfoVisible(!TextUtils.isEmpty(info));
         holder.setIcon(item.getThumbnail());
         holder.setOnClickListener(this);
-        holder.setEnabled(item.isFolder() || Util.mimeAllowed(mimeTypes, item.getMimetype()));
+        holder.setEnabled(item.isFolder() || (Util.mimeAllowed(mimeTypes, item.getMimetype())
+                && !Util.mimeExcluded(item.getMimetype())));
         Selection selection = SelectionFactory.from(sourceId, item);
         holder.setSelected(selector.isSelected(selection));
         String nextToken = nextTokens.get(currentPath);
@@ -205,6 +206,9 @@ class CloudListAdapter extends RecyclerView.Adapter<CloudListViewHolder> impleme
             return;
         }
 
+        if (Util.mimeExcluded(item.getMimetype())) {
+            return;
+        }
 
         Selection selection = SelectionFactory.from(sourceId, item);
         boolean selected = selector.toggle(selection);

--- a/filestack/src/main/java/com/filestack/android/internal/LocalFilesFragment.java
+++ b/filestack/src/main/java/com/filestack/android/internal/LocalFilesFragment.java
@@ -132,6 +132,10 @@ public class LocalFilesFragment extends Fragment implements View.OnClickListener
 
             for (Uri uri : uris) {
                 Selection selection = processUri(uri);
+                // Skip files excluded by the library (e.g. SVG)
+                if (Util.mimeExcluded(selection.getMimeType())) {
+                    continue;
+                }
                 if (Util.getSelectionSaver().add(selection)) {
                     newSelections.add(selection);
                 }

--- a/filestack/src/main/java/com/filestack/android/internal/LocalFilesFragment.java
+++ b/filestack/src/main/java/com/filestack/android/internal/LocalFilesFragment.java
@@ -140,6 +140,14 @@ public class LocalFilesFragment extends Fragment implements View.OnClickListener
                 // Skip files excluded by the library (e.g. SVG)
                 if (Util.mimeExcluded(selection.getMimeType())) {
                     excludedFiles.add(selection.getName());
+                    // Release the persisted URI permission we took in processUri()
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+                        try {
+                            getActivity().getContentResolver().releasePersistableUriPermission(
+                                    uri, Intent.FLAG_GRANT_READ_URI_PERMISSION
+                                            | Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
+                        } catch (SecurityException ignored) { }
+                    }
                     continue;
                 }
                 if (Util.getSelectionSaver().add(selection)) {

--- a/filestack/src/main/java/com/filestack/android/internal/LocalFilesFragment.java
+++ b/filestack/src/main/java/com/filestack/android/internal/LocalFilesFragment.java
@@ -24,6 +24,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.ImageView;
+import android.widget.Toast;
 
 import com.filestack.android.FsActivity;
 import com.filestack.android.FsConstants;
@@ -129,16 +130,28 @@ public class LocalFilesFragment extends Fragment implements View.OnClickListener
             }
 
             List<Selection> newSelections = new ArrayList<>();
+            List<String> excludedFiles = new ArrayList<>();
 
             for (Uri uri : uris) {
                 Selection selection = processUri(uri);
+                if (selection == null) {
+                    continue;
+                }
                 // Skip files excluded by the library (e.g. SVG)
                 if (Util.mimeExcluded(selection.getMimeType())) {
+                    excludedFiles.add(selection.getName());
                     continue;
                 }
                 if (Util.getSelectionSaver().add(selection)) {
                     newSelections.add(selection);
                 }
+            }
+
+            if (!excludedFiles.isEmpty()) {
+                String message = excludedFiles.size() == 1
+                        ? "File type not supported: " + excludedFiles.get(0)
+                        : excludedFiles.size() + " files skipped (unsupported type)";
+                Toast.makeText(getContext(), message, Toast.LENGTH_SHORT).show();
             }
 
             // inform adapter about the change

--- a/filestack/src/main/java/com/filestack/android/internal/UploadService.java
+++ b/filestack/src/main/java/com/filestack/android/internal/UploadService.java
@@ -27,6 +27,7 @@ import com.filestack.android.Selection;
 
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.UUID;
@@ -71,9 +72,21 @@ public class UploadService extends Service {
     @Override
     public int onStartCommand(Intent intent, int flags, int startId) {
         final ArrayList<Selection> selections = intent.getParcelableArrayListExtra(FsConstants.EXTRA_SELECTION_LIST);
+        final String[] mimeTypes = intent.getStringArrayExtra(FsConstants.EXTRA_MIME_TYPES);
         StorageOptions storeOpts = (StorageOptions) intent.getSerializableExtra(FsConstants.EXTRA_STORE_OPTS);
         if (storeOpts == null) {
             storeOpts = new StorageOptions.Builder().build();
+        }
+
+        // Filter out selections that are not allowed or are excluded (e.g. SVG)
+        Iterator<Selection> iterator = selections.iterator();
+        while (iterator.hasNext()) {
+            Selection selection = iterator.next();
+            String mime = selection.getMimeType();
+            boolean allowed = mimeTypes == null || mimeTypes.length == 0 || Util.mimeAllowed(mimeTypes, mime);
+            if (!allowed || Util.mimeExcluded(mime)) {
+                iterator.remove();
+            }
         }
 
         Notification serviceNotification =

--- a/filestack/src/main/java/com/filestack/android/internal/UploadService.java
+++ b/filestack/src/main/java/com/filestack/android/internal/UploadService.java
@@ -10,12 +10,8 @@ import android.content.Intent;
 import android.net.Uri;
 import android.os.Build;
 import android.os.IBinder;
-import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.core.app.JobIntentService;
 import androidx.core.app.NotificationCompat;
-import androidx.core.app.NotificationManagerCompat;
-import androidx.core.app.ServiceCompat;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
 import com.filestack.FileLink;
@@ -27,7 +23,6 @@ import com.filestack.android.Selection;
 
 import java.io.InputStream;
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.UUID;
@@ -72,21 +67,9 @@ public class UploadService extends Service {
     @Override
     public int onStartCommand(Intent intent, int flags, int startId) {
         final ArrayList<Selection> selections = intent.getParcelableArrayListExtra(FsConstants.EXTRA_SELECTION_LIST);
-        final String[] mimeTypes = intent.getStringArrayExtra(FsConstants.EXTRA_MIME_TYPES);
         StorageOptions storeOpts = (StorageOptions) intent.getSerializableExtra(FsConstants.EXTRA_STORE_OPTS);
         if (storeOpts == null) {
             storeOpts = new StorageOptions.Builder().build();
-        }
-
-        // Filter out selections that are not allowed or are excluded (e.g. SVG)
-        Iterator<Selection> iterator = selections.iterator();
-        while (iterator.hasNext()) {
-            Selection selection = iterator.next();
-            String mime = selection.getMimeType();
-            boolean allowed = mimeTypes == null || mimeTypes.length == 0 || Util.mimeAllowed(mimeTypes, mime);
-            if (!allowed || Util.mimeExcluded(mime)) {
-                iterator.remove();
-            }
         }
 
         Notification serviceNotification =

--- a/filestack/src/main/java/com/filestack/android/internal/Util.java
+++ b/filestack/src/main/java/com/filestack/android/internal/Util.java
@@ -226,4 +226,17 @@ public class Util {
         boolean allTypesAllowed = Arrays.asList(filters).contains("*/*");
         return allTypesAllowed || MimeTypeFilter.matches(mimeType, filters) != null;
     }
+
+    /** Returns true if the MIME type is excluded by the library. */
+    public static boolean mimeExcluded(String mimeType) {
+        if (mimeType == null) return false;
+        return MimeTypeFilter.matches(mimeType, EXCLUDED_MIME_TYPES) != null;
+    }
+
+    /**
+     * MIME types that are blocked from being uploaded, regardless of what the host app configures.
+     */
+    public static final String[] EXCLUDED_MIME_TYPES = {
+        "image/svg+xml"
+    };
 }


### PR DESCRIPTION
https://fieldwire.atlassian.net/browse/ME-7078

Exclude SVG MIME type from the upload service and display a toast error in the UI. Previously, `UploadService` uploaded every selection without any MIME type validation, meaning any file that made it into the selection list would be uploaded to S3 regardless of type restrictions set by the host app (Fieldwire app).

This change will be combined with the removal of `.svg` extension in the host app to fully block SVG upload

https://github.com/user-attachments/assets/54cfe4ed-8644-431e-90af-3edca037d346

Testing:
- Verified with demo app that SVG files can't be selected to upload