### PR TITLE
Edge-to-edge support

### DIFF
--- a/filestack/build.gradle
+++ b/filestack/build.gradle
@@ -43,6 +43,7 @@ dependencies {
     api 'com.github.filestack:filestack-java:0.9.0'
 
     implementation 'androidx.appcompat:appcompat:1.2.0'
+    implementation 'androidx.activity:activity:1.9.0'
 
     implementation 'androidx.browser:browser:1.3.0'
     // glide 

--- a/filestack/src/main/java/com/filestack/android/FsActivity.java
+++ b/filestack/src/main/java/com/filestack/android/FsActivity.java
@@ -15,6 +15,10 @@ import androidx.annotation.NonNull;
 import com.bumptech.glide.manager.SupportRequestManagerFragment;
 import com.google.android.material.navigation.NavigationView;
 
+import androidx.activity.EdgeToEdge;
+import androidx.core.graphics.Insets;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
 import androidx.fragment.app.Fragment;
 import androidx.core.content.ContextCompat;
 import androidx.core.graphics.ColorUtils;
@@ -109,11 +113,27 @@ public class FsActivity extends AppCompatActivity implements
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
+        EdgeToEdge.enable(this);
         super.onCreate(savedInstanceState);
         Intent intent = getIntent();
         SharedPreferences preferences = getPreferences(MODE_PRIVATE);
 
         setContentView(R.layout.filestack__activity_filestack);
+
+        // Override DrawerLayout's inset consumption (phones only — tablets use FrameLayout)
+        View drawerLayout = findViewById(R.id.drawer_layout);
+        if (drawerLayout != null) {
+            ViewCompat.setOnApplyWindowInsetsListener(drawerLayout, (view, windowInsets) -> {
+                return windowInsets;
+            });
+        }
+
+        // Apply system bar padding to main content area
+        ViewCompat.setOnApplyWindowInsetsListener(findViewById(R.id.main_layout), (view, windowInsets) -> {
+            Insets insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars());
+            view.setPadding(insets.left, insets.top, insets.right, insets.bottom);
+            return WindowInsetsCompat.CONSUMED;
+        });
 
         Toolbar toolbar = findViewById(R.id.toolbar);
         progressBar = findViewById(R.id.bar);

--- a/filestack/src/main/java/com/filestack/android/FsActivity.java
+++ b/filestack/src/main/java/com/filestack/android/FsActivity.java
@@ -135,6 +135,16 @@ public class FsActivity extends AppCompatActivity implements
             return WindowInsetsCompat.CONSUMED;
         });
 
+        // Apply system bar padding to navigation drawer so header doesn't overlap status bar
+        View navView = findViewById(R.id.nav_view);
+        if (navView != null) {
+            ViewCompat.setOnApplyWindowInsetsListener(navView, (view, windowInsets) -> {
+                Insets insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout());
+                view.setPadding(view.getPaddingLeft(), insets.top, view.getPaddingRight(), view.getPaddingBottom());
+                return WindowInsetsCompat.CONSUMED;
+            });
+        }
+
         Toolbar toolbar = findViewById(R.id.toolbar);
         progressBar = findViewById(R.id.bar);
         setSupportActionBar(toolbar);

--- a/filestack/src/main/java/com/filestack/android/FsActivity.java
+++ b/filestack/src/main/java/com/filestack/android/FsActivity.java
@@ -130,7 +130,7 @@ public class FsActivity extends AppCompatActivity implements
 
         // Apply system bar padding to main content area
         ViewCompat.setOnApplyWindowInsetsListener(findViewById(R.id.main_layout), (view, windowInsets) -> {
-            Insets insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars());
+            Insets insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout());
             view.setPadding(insets.left, insets.top, insets.right, insets.bottom);
             return WindowInsetsCompat.CONSUMED;
         });

--- a/filestack/src/main/res/layout-sw600dp/filestack__activity_filestack.xml
+++ b/filestack/src/main/res/layout-sw600dp/filestack__activity_filestack.xml
@@ -4,6 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:fitsSystemWindows="true"
     tools:context="com.filestack.android.FsActivity">
 
     <com.google.android.material.appbar.AppBarLayout

--- a/filestack/src/main/res/layout/filestack__activity_filestack.xml
+++ b/filestack/src/main/res/layout/filestack__activity_filestack.xml
@@ -5,7 +5,6 @@
     android:id="@+id/drawer_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:fitsSystemWindows="true"
     tools:openDrawer="start">
 
     <RelativeLayout


### PR DESCRIPTION
[ME-7867](https://fieldwire.atlassian.net/browse/ME-7867)

Fixes status bar overlap when the picker is hosted by an edge-to-edge app

**Phone layout** (`layout/`): Removes `fitsSystemWindows` from `DrawerLayout` (which consumed insets internally and hid them from children) and adds programmatic `WindowInsetsCompat` listeners — a no-op passthrough on `DrawerLayout` + padding on `main_layout`.

**Tablet layout** (`layout-sw600dp/`): Adds `fitsSystemWindows="true"` to root `FrameLayout` (no `DrawerLayout` interception issue here, so the simple attribute works).

Adds `androidx.activity:activity:1.9.0` for `EdgeToEdge.enable()`


[ME-7867]: https://fieldwire.atlassian.net/browse/ME-7867?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<img width="320" height="512" alt="Screenshot_20260730_080441" src="https://github.com/user-attachments/assets/7013030f-8bae-448b-b2d7-a4f7830689ab" />

Verified works on api 16 tablet on gesture mode


